### PR TITLE
Add support for changing episodes to items in the PA ingester

### DIFF
--- a/src/main/java/org/atlasapi/media/entity/Item.java
+++ b/src/main/java/org/atlasapi/media/entity/Item.java
@@ -14,24 +14,21 @@
  permissions and limitations under the License. */
 package org.atlasapi.media.entity;
 
-import static org.atlasapi.media.entity.ParentRef.parentRefFrom;
-
 import java.util.List;
 import java.util.Set;
 
 import org.atlasapi.content.rdf.annotations.RdfClass;
 import org.atlasapi.content.rdf.annotations.RdfProperty;
-import org.atlasapi.media.TransportType;
 import org.atlasapi.media.vocabulary.DC;
 import org.atlasapi.media.vocabulary.PO;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.metabroadcast.common.intl.Country;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import static org.atlasapi.media.entity.ParentRef.parentRefFrom;
 
 /**
  * @author Robert Chatley (robert@metabroadcast.com)
@@ -111,7 +108,7 @@ public class Item extends Content {
         return copy;
     }
 
-    protected static void copyTo(Item from, Item to) {
+    public static void copyTo(Item from, Item to) {
         Content.copyTo(from, to);
         if (from.parent != null) {
             to.parent = from.parent;
@@ -120,7 +117,6 @@ public class Item extends Content {
         to.blackAndWhite = from.blackAndWhite;
         to.countriesOfOrigin = Sets.newHashSet(from.countriesOfOrigin);
         to.releaseDates = from.releaseDates;
-
     }
 
     public Item withSortKey(String sortKey) {


### PR DESCRIPTION
- This was not previously supported, but the ingester is already
  converting episodes to films where needed so functionally this
  should not be any different
- Also `Item.copyTo` was set to `protected`, which meant that anyone
  calling `Item.copyTo` from outside the Item class hierarchy was
  effectively calling `Content.copyTo` which `Item` inherits and is
  thus missing some fields. Changing `Item.copyTo` to public will
  affect the `ContentMerger` class as well as the merging logic in
  the RT ingester that use this, but this should be the correct
  behaviour and it's likely that those parts of the codebase never
  intended to rely on this behaviour and instead didn't realise that
  some fields were being missed