### PR TITLE
Change OutputContentMerger to only pick IDs from selected content

### DIFF
--- a/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
+++ b/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
@@ -5,8 +5,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.StreamSupport;
 
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.common.stream.MoreCollectors;
 import org.atlasapi.media.entity.AudienceStatistics;
 import org.atlasapi.media.entity.Broadcast;
 import org.atlasapi.media.entity.Certificate;
@@ -22,7 +20,6 @@ import org.atlasapi.media.entity.Identified;
 import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
 import org.atlasapi.media.entity.Item;
-import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Person;
 import org.atlasapi.media.entity.Priority;
 import org.atlasapi.media.entity.Publisher;
@@ -31,6 +28,9 @@ import org.atlasapi.media.entity.SimilarContentRef;
 import org.atlasapi.media.entity.Subtitles;
 import org.atlasapi.media.entity.TopicRef;
 import org.atlasapi.media.entity.Version;
+
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.common.stream.MoreCollectors;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -72,7 +72,7 @@ public class OutputContentMerger {
 
             T chosen = same.get(0);
 
-            chosen.setId(lowestId(chosen));
+            chosen.setId(lowestId(chosen, same));
 
             // defend against broken transitive equivalence
             if (merged.contains(chosen)) {
@@ -95,12 +95,14 @@ public class OutputContentMerger {
         return merged;
     }
 
-    private <T extends Described> Long lowestId(T chosen) {
+    private <T extends Described> Long lowestId(T chosen, List<T> same) {
+        Ordering<Comparable> ordering = Ordering.natural().nullsLast();
+
         Long lowest = chosen.getId();
-        for (LookupRef ref : chosen.getEquivalentTo()) {
-            Long candidate = ref.id();
-            lowest = Ordering.natural().nullsLast().min(lowest, candidate);
+        for (T equivDescribed : same) {
+            lowest = ordering.min(lowest, equivDescribed.getId());
         }
+
         return lowest;
     }
 

--- a/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
+++ b/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
@@ -1,16 +1,8 @@
 package org.atlasapi.equiv;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.util.Arrays;
 import java.util.List;
 
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Container;
 import org.atlasapi.media.entity.Content;
@@ -18,14 +10,23 @@ import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
 import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Publisher;
-import org.joda.time.DateTime;
-import org.junit.Test;
+
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
 
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class OutputContentMergerTest {
 
@@ -90,7 +91,7 @@ public class OutputContentMergerTest {
     }
 
     @Test
-    public void testMergedContentHasLowestIdOfContentInEquivalenceSet() {
+    public void testMergedContentHasLowestIdOfSelectedContentInEquivalenceSet() {
         
         Brand one = brand(5L, "one", Publisher.BBC);
         Brand two = brand(2L, "two",Publisher.PA);
@@ -100,14 +101,17 @@ public class OutputContentMergerTest {
         setEquivalent(two, one, three);
         setEquivalent(three, two, one);
         
-        //two is intentionally missing here
+        // Two is intentionally missing here. It will be in the `same_as` lists of content one and
+        // two, but not in the filtered list of content that we are passing to the merger
         ImmutableList<Brand> contents = ImmutableList.of(one, three);
 
-        when(application.getConfiguration()).thenReturn(configWithReads(Publisher.BBC, Publisher.TED));
-        mergePermutations(contents, application, one, two.getId());
+        when(application.getConfiguration())
+                .thenReturn(configWithReads(Publisher.BBC, Publisher.TED));
+        mergePermutations(contents, application, one, one.getId());
 
-        when(application.getConfiguration()).thenReturn(configWithReads(Publisher.TED,Publisher.BBC));
-        mergePermutations(contents, application, three, two.getId());
+        when(application.getConfiguration())
+                .thenReturn(configWithReads(Publisher.TED,Publisher.BBC));
+        mergePermutations(contents, application, three, one.getId());
         
     }
 


### PR DESCRIPTION
- Previously we would select the ID to be shown from among all content
  in the equivalent set including content whose publisher is not enabled
  in the application. This is causing a problem with tools like
  blackout because of the following:
  -- blackout tool makes schedule call
  -- items in schedule have the lowest ID of all items
  -- potentially the item ID is from a source that is not enabled in
     the tool's key
  -- the blackout item is added against that ID
  -- in Deer the blackout item is not visible because it's only
     reachable in the equivalence graph via an item from a disabled
     source
- This changes the merger to select the lowest ID from the enabled
  content only