### PR TITLE
Added customFields map field to Identified model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-model</artifactId>
-    <version>5.2-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
     <description>Atlas API data types</description>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-model</artifactId>
-    <version>5.0-SNAPSHOT</version>
+    <version>5.2-SNAPSHOT</version>
     <description>Atlas API data types</description>
     <build>
         <plugins>

--- a/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
+++ b/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
@@ -190,6 +190,20 @@ public class OutputContentMerger {
             Iterable<T> notChosen
     ) {
         chosen.setAliases(projectFieldFromEquivalents(chosen, notChosen, Identified::getAliases));
+        mergeCustomFields(chosen, notChosen);
+    }
+
+    private <T extends Identified> void mergeCustomFields(
+            T chosen,
+            Iterable<T> notChosen
+    ) {
+        for(T identified : notChosen) {
+            for(Map.Entry<String, String> customField : identified.getCustomFields().entrySet()) {
+                if (!chosen.containsCustomFieldKey(customField.getKey())) {
+                    chosen.putCustomField(customField.getKey(), customField.getValue());
+                }
+            }
+        }
     }
 
     private <T extends Identified, P> Iterable<P> projectFieldFromEquivalents(T chosen,

--- a/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
+++ b/src/main/java/org/atlasapi/equiv/OutputContentMerger.java
@@ -200,7 +200,7 @@ public class OutputContentMerger {
         for(T identified : notChosen) {
             for(Map.Entry<String, String> customField : identified.getCustomFields().entrySet()) {
                 if (!chosen.containsCustomFieldKey(customField.getKey())) {
-                    chosen.putCustomField(customField.getKey(), customField.getValue());
+                    chosen.addCustomField(customField.getKey(), customField.getValue());
                 }
             }
         }

--- a/src/main/java/org/atlasapi/media/entity/Identified.java
+++ b/src/main/java/org/atlasapi/media/entity/Identified.java
@@ -189,16 +189,27 @@ public class Identified {
 		this.customFields = checkNotNull(customFields);
 	}
 
-	public void putCustomField(@NotNull String key, @Nullable String value) {
+	/**
+	 * Adds a key-value custom field, if the key already exists it will be overwritten
+	 * Since merging logic will combine all custom fields for everything in the equiv set proper key namespacing
+	 * may be required to avoid a custom field being ignored in favour of a higher precedence sharing the custom field.
+	 * @param key the name of the custom field
+	 * @param value the value of the custom field
+	 */
+	public void addCustomField(@NotNull String key, @Nullable String value) {
 		if(value == null) {
 			return;
 		}
 		customFields.put(checkNotNull(key), value);
 	}
 
-	public void putCustomFields(@NotNull Map<String, String> customFields) {
+	/**
+	 * Adds each key-value entry as a custom field, overwriting existing customFields which share the same key
+	 * @param customFields the map containing the key-value custom fields to add
+	 */
+	public void addCustomFields(@NotNull Map<String, String> customFields) {
 		for(Map.Entry<String, String> entry : customFields.entrySet()) {
-			putCustomField(entry.getKey(), entry.getValue());
+			addCustomField(entry.getKey(), entry.getValue());
 		}
 	}
 

--- a/src/main/java/org/atlasapi/media/entity/simple/Identified.java
+++ b/src/main/java/org/atlasapi/media/entity/simple/Identified.java
@@ -101,16 +101,27 @@ public class Identified {
 		this.customFields = checkNotNull(customFields);
 	}
 
-	public void putCustomField(@NotNull String key, @Nullable String value) {
+	/**
+	 * Adds a key-value custom field, if the key already exists it will be overwritten
+	 * Since merging logic will combine all custom fields for everything in the equiv set proper key namespacing
+	 * may be required to avoid a custom field being ignored in favour of a higher precedence sharing the custom field.
+	 * @param key the name of the custom field
+	 * @param value the value of the custom field
+	 */
+	public void addCustomField(@NotNull String key, @Nullable String value) {
 		if(value == null) {
 			return;
 		}
 		customFields.put(checkNotNull(key), value);
 	}
 
-	public void putCustomFields(@NotNull Map<String, String> customFields) {
+	/**
+	 * Adds each key-value entry as a custom field, overwriting existing customFields which share the same key
+	 * @param customFields the map containing the key-value custom fields to add
+	 */
+	public void addCustomFields(@NotNull Map<String, String> customFields) {
 		for(Map.Entry<String, String> entry : customFields.entrySet()) {
-			putCustomField(entry.getKey(), entry.getValue());
+			addCustomField(entry.getKey(), entry.getValue());
 		}
 	}
 

--- a/src/main/java/org/atlasapi/output/Annotation.java
+++ b/src/main/java/org/atlasapi/output/Annotation.java
@@ -1,7 +1,5 @@
 package org.atlasapi.output;
 
-import java.util.Set;
-
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.BiMap;
@@ -10,6 +8,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.metabroadcast.common.text.MoreStrings;
+
+import java.util.Set;
 
 public enum Annotation {
 
@@ -58,6 +58,7 @@ public enum Annotation {
     PAYLOAD,
     RESPECT_API_KEY_FOR_EQUIV_LIST,
     ALLOW_MULTIPLE_FROM_SAME_PUBLISHER_IN_EQUIV_LIST,
+    CUSTOM_FIELDS
     ;
     
     private static final ImmutableSet<Annotation> defaultAnnotations = ImmutableSet.of(

--- a/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
+++ b/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
@@ -1,8 +1,12 @@
 package org.atlasapi.equiv;
 
-import java.util.Arrays;
-import java.util.List;
-
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.metabroadcast.applications.client.model.internal.Application;
+import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
 import org.atlasapi.media.entity.Alias;
 import org.atlasapi.media.entity.Brand;
 import org.atlasapi.media.entity.Broadcast;
@@ -12,17 +16,11 @@ import org.atlasapi.media.entity.Image;
 import org.atlasapi.media.entity.ImageType;
 import org.atlasapi.media.entity.LookupRef;
 import org.atlasapi.media.entity.Publisher;
-
-import com.metabroadcast.applications.client.model.internal.Application;
-import com.metabroadcast.applications.client.model.internal.ApplicationConfiguration;
-
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -113,6 +111,34 @@ public class OutputContentMergerTest {
                 .thenReturn(configWithReads(Publisher.TED,Publisher.BBC));
         mergePermutations(contents, application, three, one.getId());
         
+    }
+
+    @Test
+    public void testCustomFieldsMergeCorrectly() {
+        Brand one = brand(1L, "one",Publisher.BBC);
+        Brand two = brand(2L, "two",Publisher.PA);
+        Brand three = brand(3L, "three",Publisher.TED);
+
+        one.putCustomField("customField", "1");
+        two.putCustomField("customField", "2");
+        three.putCustomField("customField", "3");
+        one.putCustomField("additionalField", "1");
+        three.putCustomField("additionalField", "3");
+        three.putCustomField("additionalField2", "3");
+
+        setEquivalent(one, two, three);
+        setEquivalent(two, one, three);
+        setEquivalent(three, two, one);
+
+        when(application.getConfiguration()).thenReturn(configWithReads(Publisher.PA, Publisher.BBC, Publisher.TED));
+
+        ImmutableList<Brand> contents = ImmutableList.of(one, two, three);
+
+        List<Brand> merged = merger.merge(application, contents);
+        Brand mergedBrand = Iterables.getOnlyElement(merged);
+        assertThat(mergedBrand.getCustomField("customField"), is("2"));
+        assertThat(mergedBrand.getCustomField("additionalField"), is("1"));
+        assertThat(mergedBrand.getCustomField("additionalField2"), is("3"));
     }
 
     @Test

--- a/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
+++ b/src/test/java/org/atlasapi/equiv/OutputContentMergerTest.java
@@ -119,12 +119,12 @@ public class OutputContentMergerTest {
         Brand two = brand(2L, "two",Publisher.PA);
         Brand three = brand(3L, "three",Publisher.TED);
 
-        one.putCustomField("customField", "1");
-        two.putCustomField("customField", "2");
-        three.putCustomField("customField", "3");
-        one.putCustomField("additionalField", "1");
-        three.putCustomField("additionalField", "3");
-        three.putCustomField("additionalField2", "3");
+        one.addCustomField("customField", "1");
+        two.addCustomField("customField", "2");
+        three.addCustomField("customField", "3");
+        one.addCustomField("additionalField", "1");
+        three.addCustomField("additionalField", "3");
+        three.addCustomField("additionalField2", "3");
 
         setEquivalent(one, two, three);
         setEquivalent(two, one, three);

--- a/src/test/java/org/atlasapi/media/entity/IdentifiedTest.java
+++ b/src/test/java/org/atlasapi/media/entity/IdentifiedTest.java
@@ -1,0 +1,22 @@
+package org.atlasapi.media.entity;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IdentifiedTest {
+
+    @Test
+    public void testGettingCustomFieldKeys() {
+        Identified identified = new Identified();
+        identified.addCustomField("customField", "1");
+        identified.addCustomField("additionalField", "2");
+        identified.addCustomField("additionalField2", "3");
+        assertThat(identified.getCustomFieldKeys(null), is(ImmutableSet.of("customField", "additionalField", "additionalField2")));
+        assertThat(identified.getCustomFieldKeys("additional.*"), is(ImmutableSet.of("additionalField", "additionalField2")));
+        assertThat(identified.getCustomFieldKeys("custom.*"), is(ImmutableSet.of("customField")));
+        assertThat(identified.getCustomFieldKeys(".*Field.*"), is(identified.getCustomFieldKeys(null)));
+    }
+}

--- a/src/test/java/org/atlasapi/media/entity/simple/IdentifiedTest.java
+++ b/src/test/java/org/atlasapi/media/entity/simple/IdentifiedTest.java
@@ -1,0 +1,22 @@
+package org.atlasapi.media.entity.simple;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class IdentifiedTest {
+
+    @Test
+    public void testGettingCustomFieldKeys() {
+        Identified identified = new Identified();
+        identified.addCustomField("customField", "1");
+        identified.addCustomField("additionalField", "2");
+        identified.addCustomField("additionalField2", "3");
+        assertThat(identified.getCustomFieldKeys(null), is(ImmutableSet.of("customField", "additionalField", "additionalField2")));
+        assertThat(identified.getCustomFieldKeys("additional.*"), is(ImmutableSet.of("additionalField", "additionalField2")));
+        assertThat(identified.getCustomFieldKeys("custom.*"), is(ImmutableSet.of("customField")));
+        assertThat(identified.getCustomFieldKeys(".*Field.*"), is(identified.getCustomFieldKeys(null)));
+    }
+}


### PR DESCRIPTION
The field is intended to be used for arbitrary data
that does not fit within the confines of the regular
atlas model e.g. additional title fields or customer-specific
fields.

Added merging logic for customFields which will
merge fields from each map into the highest-precedence
customFields map where the field does not already exist.
This is to mimic behaviour of merging logic of regular
fields.

Added a custom_fields annotation which will be used to output
the field.